### PR TITLE
Incoming breakage: fix name collision in Rust 1.91 (current beta)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install bzip2 development package
+        run: sudo apt-get update && sudo apt-get install -y libbz2-dev
+
       - uses: taiki-e/install-action@just
 
       - uses: actions/cache@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install bzip2 development package
-        run: sudo apt-get update && sudo apt-get install -y libbz2-dev
+        run: sudo apt-get update && sudo apt-get install -y libbz2-dev liblzma-dev
 
       - uses: taiki-e/install-action@just
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -262,13 +262,13 @@ impl Build {
     }
     fn prg_index_path(&self) -> PathBuf {
         let ext = format!("k{}.w{}.idx", self.pandora_k, self.pandora_w);
-        self.prg_path().add_extension(ext.as_str().as_ref())
+        PathExt::add_extension(self.prg_path().as_path(), ext.as_str().as_ref())
     }
     fn prg_index_kmer_prgs_path(&self) -> PathBuf {
         self.outdir.join("kmer_prgs")
     }
     fn reference_index_file(&self) -> PathBuf {
-        self.reference_file.add_extension(".fai".as_ref())
+        PathExt::add_extension(self.reference_file.as_path(), ".fai".as_ref())
     }
     fn organise_prebuilt_prg(&self) -> Result<(), BuildError> {
         let prebuilt_dir = match &self.prebuilt_prg {

--- a/src/expert.rs
+++ b/src/expert.rs
@@ -140,9 +140,7 @@ impl RuleExt for ExpertRules {
         for result in reader.deserialize() {
             n_records += 1;
             let record: Rule = result?;
-            let set_of_records = rules
-                .entry(record.gene.to_owned())
-                .or_insert_with(HashSet::new);
+            let set_of_records = rules.entry(record.gene.to_owned()).or_default();
             let seen_before = !set_of_records.insert(record);
 
             if seen_before {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use regex::Regex;
 use std::cmp::{max, min};
 use std::collections::HashSet;
 use std::fs;
-use std::io::{BufReader, BufWriter, ErrorKind};
+use std::io::{BufReader, BufWriter};
 
 pub mod filter;
 pub mod interval;
@@ -128,8 +128,7 @@ impl Bcftools {
 
         if !cmd_output.status.success() {
             let exit_code = cmd_output.status.to_string();
-            Err(DependencyError::ProcessError(std::io::Error::new(
-                ErrorKind::Other,
+            Err(DependencyError::ProcessError(std::io::Error::other(
                 format!(
                     "{} with stderr: {}",
                     exit_code,
@@ -171,8 +170,7 @@ impl Bcftools {
 
         if !cmd_output.status.success() {
             let exit_code = cmd_output.status.to_string();
-            Err(DependencyError::ProcessError(std::io::Error::new(
-                ErrorKind::Other,
+            Err(DependencyError::ProcessError(std::io::Error::other(
                 format!(
                     "{} with stderr: {}",
                     exit_code,
@@ -1174,7 +1172,9 @@ impl VcfExt for bcf::Record {
     }
 
     fn has_no_depth(&self) -> bool {
-        let Some((fc, rc)) = self.coverage() else { return true };
+        let Some((fc, rc)) = self.coverage() else {
+            return true;
+        };
         let total_depth: i32 = fc.iter().chain(rc.iter()).sum();
         total_depth == 0
     }

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -33,9 +33,7 @@ impl PanelExt for Panel {
         for result in reader.deserialize() {
             n_records += 1;
             let record: PanelRecord = result?;
-            let set_of_records = panel
-                .entry(record.gene.to_owned())
-                .or_insert_with(HashSet::new);
+            let set_of_records = panel.entry(record.gene.to_owned()).or_default();
             let seen_before = !set_of_records.insert(record);
 
             if seen_before {

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -361,7 +361,7 @@ impl Predict {
     }
 
     fn index_vcf_index_path(&self) -> PathBuf {
-        self.index_vcf_path().add_extension(".csi".as_ref())
+        PathExt::add_extension(self.index_vcf_path().as_path(), ".csi".as_ref())
     }
 
     fn index_vcf_ref_path(&self) -> PathBuf {
@@ -384,8 +384,8 @@ impl Predict {
     }
 
     fn predict_vcf_filename(&self) -> PathBuf {
-        let path = PathBuf::from(self.sample_name());
-        path.add_extension(".drprg.bcf".as_ref())
+        let path = Path::new(self.sample_name());
+        PathExt::add_extension(path, ".drprg.bcf".as_ref())
     }
 
     fn discover_dir(&self) -> PathBuf {
@@ -393,8 +393,8 @@ impl Predict {
     }
 
     fn json_filename(&self) -> PathBuf {
-        let path = PathBuf::from(self.sample_name());
-        path.add_extension(".drprg.json".as_ref())
+        let path = Path::new(self.sample_name());
+        PathExt::add_extension(path, ".drprg.json".as_ref())
     }
 
     fn validate_index(&self) -> Result<(), PredictError> {

--- a/src/report.rs
+++ b/src/report.rs
@@ -48,7 +48,7 @@ impl Evidence {
             .reference
             .len()
             .abs_diff(self.variant.new.len());
-        self.residue == Residue::Nucleic && len_diff % 3 != 0
+        self.residue == Residue::Nucleic && !len_diff.is_multiple_of(3)
     }
     pub fn atomise(&self) -> Vec<Self> {
         if self.variant.is_snp() || self.variant.is_indel() {


### PR DESCRIPTION
The upcoming Rust version 1.91 (currently in beta) can't compile drprg 0.1.1 because a new addition to the standard library (`PathBuf::add_extension`) collides with a method on drprg's `PathExt` extension trait. Rust versions 1.81 -- 1.90 emit a warning about this:

```
warning: a method with this name may be added to the standard library in the future
   --> src/builder.rs:265:25
    |
265 |         self.prg_path().add_extension(ext.as_str().as_ref())
    |                         ^^^^^^^^^^^^^
    |
    = warning: once this associated item is added to the standard library, the ambiguity may cause an error or change in behavior!
    = note: for more information, see issue #48919 <https://github.com/rust-lang/rust/issues/48919>
    = help: call with fully qualified syntax `add_extension(...)` to keep using the current method
    = note: `#[warn(unstable_name_collisions)]` on by default
```

See the link emitted by the compiler for more context: https://github.com/rust-lang/rust/issues/48919

Rust 1.91 will stabilize this method, which causes a compiler error due to different return types (see https://github.com/rust-lang/rust/issues/147979). This PR avoids that error and keeps the previous behavior of the code by explicitly calling the `PathExt` method. This isn't pretty, but I am not familiar with drprg and didn't manage to run all tests on my machine, so I don't feel confident making more involved changes.